### PR TITLE
Mocha context related improvements

### DIFF
--- a/context-proxy.js
+++ b/context-proxy.js
@@ -1,0 +1,95 @@
+module.exports = ContextProxy;
+
+/**
+ * Proxy object for the test context.
+ * Allows to store async spec context configurations
+ * and apply them to the mocha test context when it becomes available
+ *
+ * @param {Spec} [spec] used to store context configurations
+ */
+function ContextProxy(spec) {
+    this.spec = spec;
+    this.config = {};
+}
+
+/**
+ * Set test timeout `ms`.
+ *
+ * @param {number} ms
+ * @return {ContextProxy} self
+ */
+ContextProxy.prototype.timeout = function(ms) {
+    if(this.spec){
+        this.spec.timeout = setTimeout(function() {
+            var error = new Error('timeout of ' + ms + 'ms exceeded. Ensure the ' +
+                'done() callback is being called in this test.');
+            error.stack = null;
+            throw error;
+        }, ms);
+    }
+
+    this.config.timeout = ms;
+    return this;
+};
+
+/**
+ * Set test slowness threshold `ms`.
+ *
+ * @param {number} ms
+ * @return {ContextProxy} self
+ */
+ContextProxy.prototype.slow = function(ms) {
+    this.config.slow = ms;
+    return this;
+};
+
+
+/**
+ * Mark a test as skipped.
+ *
+ * @return {ContextProxy} self
+ */
+ContextProxy.prototype.skip = function() {
+    this.config.skip = true;
+    return this;
+};
+
+/**
+ * Apply stored configurations to the mocha test context
+ *
+ * @param {Context} test_ctx
+ */
+ContextProxy.prototype.patchContext = function(test_ctx) {
+
+    if(this.spec && this.spec.timeout)
+        test_ctx.timeout(0); //Disable timeout if one is already running
+    else if(this.config.timeout)
+        test_ctx.timeout(this.config.timeout);
+
+    if(this.config.slow)
+        test_ctx.slow(this.config.slow);
+
+    if(this.config.skip)
+        test_ctx.skip();
+
+    //Hack duration variable of the test runnable to use the actual duration of the spec.
+    if(this.spec && test_ctx.runnable){
+        var spec = this.spec;
+        var orig_duration = test_ctx.runnable().duration;
+        delete test_ctx.runnable().duration;
+        Object.defineProperty(test_ctx.runnable(), "duration", {
+            get: function () {
+                return spec.duration || orig_duration;
+            },
+            set: function (duration) {
+                orig_duration = duration;
+            },
+            enumerable: true,
+            configurable: true
+        });
+    }
+
+
+};
+
+

--- a/fixtures/defaultTimeout.js
+++ b/fixtures/defaultTimeout.js
@@ -1,0 +1,13 @@
+var parallel = require('../index.js');
+//Based on issue #13
+
+parallel("suite", function () {
+    var its = ["test1", "test2"]
+    its.forEach(function (name) {
+        it(name, function () {
+            return new Promise(function (resolve) {
+                setTimeout(resolve, 2500)
+            })
+        })
+    })
+});

--- a/fixtures/defaultTimeout.js
+++ b/fixtures/defaultTimeout.js
@@ -1,4 +1,5 @@
 var parallel = require('../index.js');
+var Promise = require('bluebird');
 //Based on issue #13
 
 parallel("suite", function () {

--- a/fixtures/index.js
+++ b/fixtures/index.js
@@ -4,7 +4,7 @@ var absolutePaths = {};
 var fixtures = ['delay', 'multiple', 'hooks', 'hooksExample',
   'uncaughtException', 'parallelSkip', 'skip', 'only', 'parallelOnly',
   'failure', 'assertionFailure', 'parentHooks', 'sync', 'contextSkip',
-  'contextTimeout', 'disable'];
+  'contextTimeout', 'disable','proxyContext','defaultTimeout'];
 
 fixtures.forEach(function(fixture) {
   absolutePaths[fixture] = path.resolve(__dirname, fixture + '.js');

--- a/fixtures/proxyContext.js
+++ b/fixtures/proxyContext.js
@@ -1,0 +1,27 @@
+var parallel = require('../index.js');
+var assert   = require('assert');
+
+parallel("suite", function () {
+    this.timeout(3000);
+    this.slow(2600);
+
+    it('test1', function(done) {
+        this.timeout(100);
+        setTimeout(done, 500);
+    });
+
+    it('test2', function(done) {
+        this.skip();
+        setTimeout(done, 500);
+    });
+
+    it('test3', function(done) {
+        this.slow(200);
+        setTimeout(done, 500);
+    });
+
+    it('test4', function(done) {
+        setTimeout(done, 2500);
+    });
+
+});

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ var assert   = require('assert');
 var fixtures = require('./fixtures');
 
 describe('parallel', function() {
-  this.timeout(2000);
+  this.timeout(3000);
 
   it('runs specs in parallel', function(done) {
     var cmd = './node_modules/.bin/mocha ' + fixtures.delay;
@@ -245,6 +245,45 @@ describe('parallel', function() {
       // Specs should run in 1s
       var timeStr = stdout.match(/passing \((\d+)s\)/)[1];
       assert.equal(parseInt(timeStr, 10), 1);
+
+      done();
+    });
+  });
+
+
+  it('supports this.timeout(), this.slow(), this.skip() from a spec and parallel', function(done) {
+    var cmd = './node_modules/.bin/mocha -c ' + fixtures.proxyContext;
+    exec(cmd, function(err, stdout, stderr) {
+      assert(err);
+      assert(!stderr.length);
+      assert(stdout.indexOf('2 passing') !== -1);
+      assert(stdout.indexOf('1 pending') !== -1);
+      assert(stdout.indexOf('1 failing') !== -1);
+      assert(stdout.indexOf('1) suite test1:') !== -1);
+      assert(stdout.indexOf('timeout of 100ms exceeded. Ensure the done() ' +
+              'callback is being called in this test.') !== -1);
+      assert(stdout.indexOf('test3[0m[31m') !== -1);
+      assert(stdout.indexOf('test4[0m[33m') !== -1);
+
+      done();
+    });
+  });
+
+  it('correctly handles default timeout', function(done) {
+    var cmd = './node_modules/.bin/mocha ' + fixtures.defaultTimeout;
+    exec(cmd, function(err, stdout, stderr) {
+      assert(err);
+      assert(!stderr.length);
+      assert(stdout.indexOf('0 passing') !== -1);
+      assert(stdout.indexOf('2 failing') !== -1);
+      assert(stdout.indexOf('1) suite test1:') !== -1);
+      assert(stdout.indexOf('2) suite test2:') !== -1);
+      var i = stdout.indexOf('timeout of 2000ms exceeded. Ensure the done() ' +
+          'callback is being called in this test.');
+      assert(i !== -1);
+      i = stdout.indexOf('timeout of 2000ms exceeded. Ensure the done() ' +
+          'callback is being called in this test.',i+1);
+      assert(i !== -1);
 
       done();
     });


### PR DESCRIPTION
This allows the mocha reporters to display the actual duration of an async spec. And also allows the implementation of this.slow() in the spec context.  It also seems to fix issue #13. 
Any feedback would be appreciated