### PR TITLE
Changed mocha to be a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/danielstjules/mocha.parallel/issues"
   },
   "homepage": "https://github.com/danielstjules/mocha.parallel",
-  "devDependencies": {
+  "peerDependencies": {
     "mocha": "^2.2.5"
   },
   "dependencies": {


### PR DESCRIPTION
Make it a peerDependency will allow users of this module to use their own versions of mocha, which is ideal.