### PR TITLE
Fix crash when there are no exception listeners

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -367,11 +367,16 @@ function patchUncaught() {
   var name = 'uncaughtException';
   var originalListener = process.listeners(name).pop();
 
-  process.removeListener(name, originalListener);
+  if (originalListener !== undefined) {
+    process.removeListener(name, originalListener);
 
-  return function() {
-    process.on(name, originalListener);
-  };
+    return function() {
+      process.on(name, originalListener);
+    };
+  } else {
+    return function() {
+    };
+  }
 }
 
 Promise.onPossiblyUnhandledRejection(function() {


### PR DESCRIPTION
I ran into a crash when the process had no exception listeners registered.  Roughly I was doing something like this:

```
before(function(callback) { /* ... */ callback(); });
after(function(callback) { /* ... */ callback(); });

parallel(function() {
  // parallel tests as normal
});
```
