### PR TITLE
Support xit shorthand for it.skip

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -215,7 +215,7 @@ function patchIt(specs) {
     createSpec(name, fn);
   };
 
-  it.skip = function skip(name, fn) {
+  xit = it.skip = function skip(name, fn) {
     createSpec(name, fn, {skip: true});
   };
 


### PR DESCRIPTION
Mocha supports a shorthand for it.skip: you can just write "xit" instead of "it".
It would be awesome to keep mocha.parallel syntax consistent with mainstream mocha