### PR TITLE
Fix to throw errors properly

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -311,7 +311,7 @@ function createWrapper(fn, ctx) {
       if (!fn.length || (res && res.then)) {
         Promise.resolve(res).then(function() {
           resolve(Date.now() - start);
-        });
+        }, reject);
       }
     });
   };


### PR DESCRIPTION
Thank you for maintaining, I love this library :)
I fixed a promise error handling, could you review it?

If a promise causes an error, the error is not thrown. Then it causes a timeout error. 

```
const assert = require('assert');
const parallel = require('mocha.parallel');

parallel('test', () => {

  it('should throw an AssertionError', () => {

    return Promise.resolve()
      .then(() => assert(false));
  });
});
```

// v0.15.1

```
  1) test should throw an AssertionError:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

// ↓

```
  1) test should throw an AssertionError:

      AssertionError: false == true
      + expected - actual

      -false
      +true
```