### PR TITLE
Fix #40 - afterEach unregistered in parent context

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -391,7 +391,7 @@ function enableEachHooks(context) {
   delete context._disabledAfterEach;
 
   if (!context.parent) return;
-  disableEachHooks(context.parent);
+  enableEachHooks(context.parent);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "semaphore": "^1.0.5"
   },
   "devDependencies": {
-    "dirmap": "0.0.2"
+    "dirmap": "0.0.2",
+    "mocha": "^5.2.0"
   }
 }

--- a/spec/fixtures/parentHooks.js
+++ b/spec/fixtures/parentHooks.js
@@ -20,11 +20,25 @@ describe('suiteA', function() {
     }, 50);
   });
 
+  afterEach(function(done) {
+    process.stdout.write('suiteAAfterEach, ');
+    setTimeout(function() {
+      done();
+    }, 50);
+  });
+
   describe('suiteB', function() {
     beforeEach(function(done) {
       process.stdout.write('suiteBBeforeEach, ');
       setTimeout(function() {
         i++;
+        done();
+      }, 50);
+    });
+
+    afterEach(function(done) {
+      process.stdout.write('suiteBAfterEach, ');
+      setTimeout(function() {
         done();
       }, 50);
     });
@@ -49,7 +63,7 @@ describe('suiteA', function() {
 
       it('test2', function(done) {
         process.stdout.write('test2\n');
-        // Incremented by before, 6x beforeEach
+        // Incremented by before and 6x beforeEach
         setTimeout(function() {
           assert.equal(i, 7);
           done();

--- a/spec/fixtures/parentHooksRegression.js
+++ b/spec/fixtures/parentHooksRegression.js
@@ -1,0 +1,97 @@
+var assert = require('assert');
+var parallel = require('../../lib/parallel');
+
+describe('parent hooks regression #47', function() {
+
+  beforeEach(function() {
+    process.stdout.write('globalBeforeEach, ')
+  });
+
+  afterEach(function() {
+    process.stdout.write('globalAfterEach, ')
+  });
+
+  describe('run parallel', function() {
+    parallel('trigger hooks removal', function() {
+      it('one', function() {
+        assert(true);
+      });
+      it('two', function() {
+        assert(true);
+      });
+    })
+  });
+
+  describe('suiteA', function() {
+    var i = 0;
+
+    before(function(done) {
+      setTimeout(function() {
+        assert.equal(i, 0);
+        i++;
+        done();
+      }, 100);
+    });
+
+    beforeEach(function(done) {
+      process.stdout.write('suiteABeforeEach, ');
+      setTimeout(function() {
+        i++;
+        done();
+      }, 50);
+    });
+
+    afterEach(function(done) {
+      process.stdout.write('suiteAAfterEach, ');
+      setTimeout(function() {
+        done();
+      }, 50);
+    });
+
+    describe('suiteB', function() {
+      beforeEach(function(done) {
+        process.stdout.write('suiteBBeforeEach, ');
+        setTimeout(function() {
+          i++;
+          done();
+        }, 50);
+      });
+
+      afterEach(function(done) {
+        process.stdout.write('suiteBAfterEach, ');
+        setTimeout(function() {
+          done();
+        }, 50);
+      });
+
+      describe('hooks', function() {
+        beforeEach(function(done) {
+          process.stdout.write('childBeforeEach, ');
+          setTimeout(function() {
+            i++;
+            done();
+          }, 50);
+        });
+
+        it('test1', function(done) {
+          process.stdout.write('test1, ');
+          // Incremented by before and 4x beforeEach
+          setTimeout(function() {
+            assert.equal(i, 4);
+            done();
+          }, 1000);
+        });
+
+        it('test2', function(done) {
+          process.stdout.write('test2\n');
+          // Incremented by before and 6x beforeEach
+          setTimeout(function() {
+            assert.equal(i, 7);
+            done();
+          }, 1000);
+        });
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
This appears to have been a typo. 

Manifested in a pretty odd way, with this error in another lib:

```
Error: Missing current test, cannot make snapshot
      at snapshot (node_modules/snap-shot-it/src/index.js:87:11)
      at Context.it (example2.spec.js:5:2)
```

Essentially, the way one of our specs was written, the `afterEach()` required by `snap-shot-it` got unregistered by `parallel` usage in another spec. Given how this function here in mocha.parallel is written, it appears safe to change.