### PR TITLE
Add power-assert for more descriptive error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run async mocha specs in parallel",
   "main": "lib/parallel.js",
   "scripts": {
-    "test": "mocha spec/spec.js"
+    "test": "mocha --require intelli-espower-loader spec/spec.js"
   },
   "repository": {
     "type": "git",
@@ -31,6 +31,9 @@
     "semaphore": "^1.0.5"
   },
   "devDependencies": {
-    "dirmap": "0.0.2"
+    "dirmap": "0.0.2",
+    "intelli-espower-loader": "^1.0.1",
+    "mocha": "^5.2.0",
+    "power-assert": "^1.6.0"
   }
 }


### PR DESCRIPTION
Errors like https://travis-ci.org/danielstjules/mocha.parallel/jobs/424397432 in CI are very difficult to debug. With power-assert, we get the actual assertion we were trying to match and the value of each var used inside the `assert()` body, making this much easier.