### PR TITLE
Provide the spec's title - similar to mocha's runnable interface

### DIFF
--- a/lib/contextProxy.js
+++ b/lib/contextProxy.js
@@ -6,7 +6,17 @@
 function ContextProxy(spec) {
   this.spec = spec;
   this.config = {};
+  this.title = spec ? spec.name : undefined;
 }
+
+/**
+ * Returns the full title of the test.
+ *
+ * @return {string}
+ */
+ContextProxy.prototype.fullTitle = function() {
+  return this.title;
+};
 
 /**
  * Set test timeout.

--- a/lib/contextProxy.js
+++ b/lib/contextProxy.js
@@ -4,19 +4,9 @@
  * @param {Spec} [spec]
  */
 function ContextProxy(spec) {
-  this.spec = spec;
+  this.spec = spec || {};
   this.config = {};
-  this.title = spec ? spec.name : undefined;
 }
-
-/**
- * Returns the full title of the test.
- *
- * @return {string}
- */
-ContextProxy.prototype.fullTitle = function() {
-  return this.title;
-};
 
 /**
  * Set test timeout.

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -223,6 +223,10 @@ function patchIt(specs) {
 
     var spec = {
       name: name,
+      title: name,
+      fullTitle: function() {
+        return this.title;
+      },
       getPromise: function() {
         var start = Date.now();
         return createWrapper(fn, spec.ctx)().then(function(duration) {

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -224,6 +224,9 @@ function patchIt(specs) {
     var spec = {
       name: name,
       title: name,
+      titlePath: function() {
+        return this.title;
+      },
       fullTitle: function() {
         return this.title;
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha.parallel",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Run async mocha specs in parallel",
   "main": "lib/parallel.js",
   "scripts": {

--- a/spec/fixtures/contextProxy.js
+++ b/spec/fixtures/contextProxy.js
@@ -28,6 +28,7 @@ parallel('suite', function() {
     assert.strictEqual('test5', this.spec.title);
     assert.strictEqual('test5', this.spec.fullTitle());
     assert.strictEqual('test5', this.spec.name);
+    assert.strictEqual('test5', this.spec.titlePath());
     done();
   });
 });

--- a/spec/fixtures/contextProxy.js
+++ b/spec/fixtures/contextProxy.js
@@ -23,4 +23,11 @@ parallel('suite', function() {
   it('test4', function(done) {
     setTimeout(done, 2500);
   });
+
+  it('test5', function(done) {
+    assert.strictEqual('test5', this.spec.title);
+    assert.strictEqual('test5', this.spec.fullTitle());
+    assert.strictEqual('test5', this.spec.name);
+    done();
+  });
 });

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -259,11 +259,12 @@ describe('parallel', function() {
       stdout = stdout.replace(/\n\s+/g, ' '); // remove new lines
       assert(err);
       assert(!stderr.length);
-      assert(stdout.indexOf('2 passing') !== -1);
+      assert(stdout.indexOf('3 passing') !== -1);
       assert(stdout.indexOf('1 pending') !== -1);
       assert(stdout.indexOf('1 failing') !== -1);
       assert(stdout.indexOf('1) suite test1:') !== -1);
       assert(stdout.indexOf('timeout of 100ms exceeded') !== -1);
+
 
       done();
     });


### PR DESCRIPTION
Provide the spec's title - similar to mocha's runnable interface :)

```js
it('test5', function(done) {
    assert.strictEqual('test5', this.spec.title);
    assert.strictEqual('test5', this.spec.fullTitle());
    assert.strictEqual('test5', this.spec.titlePath());
    assert.strictEqual('test5', this.spec.name);
    done();
});
```