### PR TITLE
Feature/enable retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ npm install --save-dev mocha.parallel
  * and this.timeout() may be used from within a spec. parallel.disable()
  * may be invoked to use mocha's default test behavior, and parallel.enable()
  * will re-enable the module. parallel.limit(n) can be used to limit the number
- * of specs running simultaneously.
+ * of specs running simultaneously. parallel.maxRetries(n) is useful if some 
+ * tests have dependecies (ex: network) that fail from time to time. 
+ * parallel.retryTimeoutInMiliseconds(n) is useful if some tests hang from time 
+ * to time. parallel.getRetriedTestFailures() can be used to include retried 
+ * test failures in a custom Mocha reporter. 
+
  *
  * @example
  * parallel('setTimeout', function() {

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -15,7 +15,11 @@ var semaphore;
  * and this.timeout() may be used from within a spec. parallel.disable()
  * may be invoked to use mocha's default test behavior, and parallel.enable()
  * will re-enable the module. parallel.limit(n) can be used to limit the number
- * of specs running simultaneously.
+ * of specs running simultaneously. parallel.maxRetries(n) is useful if some 
+ * tests have dependecies (ex: network) that fail from time to time. 
+ * parallel.retryTimeoutInMiliseconds(n) is useful if some tests hang from time 
+ * to time. parallel.getRetriedTestFailures() can be used to include retried 
+ * test failures in a custom Mocha reporter. 
  *
  * @example
  * parallel('setTimeout', function() {

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -42,6 +42,11 @@ function parallel(name, fn) {
  */
 var enabled = true;
 
+var maxRetries = 5;
+var retryTimeoutInMiliseconds = 240000;
+var retryDelayInMilisecondes = 5000;
+
+
 /**
  * Private function invoked by parallel.
  *
@@ -204,6 +209,19 @@ parallel.enable = function() {
  */
 parallel.disable = function() {
   enabled = false;
+};
+
+
+parallel.maxRetries = function(x) {
+  maxRetries = x;
+};
+
+parallel.retryTimeoutInMiliseconds = function(x) {
+  retryTimeoutInMiliseconds = x;
+};
+
+parallel.retryDelayInMilisecondes = function(x) {
+  retryDelayInMilisecondes = x;
 };
 
 parallel.getRetriedTestFailures = function(){
@@ -421,9 +439,6 @@ function patchUncaught() {
   };
 }
 
-const maxRetries = 2;
-const retryTimeoutInMiliseconds = 20000;
-const retryDelayInMilisecondes = 0;
 let retriedTestFailures = [];
 
 async function executeSpecWithRetries(spec){

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -206,6 +206,10 @@ parallel.disable = function() {
   enabled = false;
 };
 
+parallel.getRetriedTestFailures = function(){
+  return [...retriedTestFailures];
+}
+
 /**
  * Patches the global it() function used by mocha, and returns a function that
  * restores the original behavior when invoked.
@@ -418,7 +422,10 @@ function patchUncaught() {
 }
 
 const maxRetries = 2;
-const timeoutBeforeRetryInMiliseconds = 20000;
+const retryTimeoutInMiliseconds = 20000;
+const retryDelayInMilisecondes = 0;
+let retriedTestFailures = [];
+
 async function executeSpecWithRetries(spec){
   let testExecutionIndex=0;
 
@@ -426,31 +433,38 @@ async function executeSpecWithRetries(spec){
     try{
       return await timeout(
         spec.getPromise(), 
-        timeoutBeforeRetryInMiliseconds, 
-        new Error(`timeoutBeforeRetryError: timeout of ${timeoutBeforeRetryInMiliseconds}ms before retrying the test is exceeded. Ensure the 'done() callback is being called in this test.`)
+        retryTimeoutInMiliseconds, 
+        new Error(`timeoutBeforeRetryError: timeout of ${retryTimeoutInMiliseconds}ms before retrying the test is exceeded. Ensure the 'done() callback is being called in this test.`)
       );
     }
     catch(err){
-      console.log(
-`"${spec.name}" failed ${testExecutionIndex+1} times. 
-Error: 
-${err}`
-      );
+      retriedTestFailures.push({
+        "specName": spec.name,
+        "testExecutionIndex": testExecutionIndex,
+        "err": err
+      })      
 
-      testExecutionIndex++;
-      if(testExecutionIndex>maxRetries){
-        throw err;
+      if(testExecutionIndex<maxRetries){
+        await sleep(retryDelayInMilisecondes);
+        testExecutionIndex++;  
+      }
+      else{
+        throw err;        
       }
     }
   }
 }
 
-const timeout = (prom, time, exception) => {
+function timeout(prom, time, exception){
 	let timer;
 	return Promise.race([
 		prom,
 		new Promise((_r, rej) => timer = setTimeout(rej, time, exception))
 	]).finally(() => clearTimeout(timer));
+}
+
+function sleep(time){
+  return new Promise(resolve => setTimeout(resolve, time));
 }
 
 

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -42,8 +42,8 @@ function parallel(name, fn) {
  */
 var enabled = true;
 
-var maxRetries = 5;
-var retryTimeoutInMiliseconds = 240000;
+var maxRetries = null;
+var retryTimeoutInMiliseconds = null;
 
 /**
  * Private function invoked by parallel.
@@ -93,7 +93,7 @@ function _parallel(name, fn, key) {
           .cancellable()
           .then(hooks.beforeEach)
           .then(async function(){
-            return executeSpecWithRetries(spec);
+            return executeSpecWithRetriesIfSpecified(spec)
           })
           .then(function() {
             clearTimeout(spec.timeout);
@@ -435,16 +435,33 @@ function patchUncaught() {
 
 let retriedTestFailures = [];
 
+async function executeSpecWithRetriesIfSpecified(spec){
+  if(!isPositiveNumber(maxRetries)){
+    return await spec.getPromise();
+  }
+
+  return await executeSpecWithRetries(spec);
+}
+
+function isPositiveNumber(x){
+  return typeof x == 'number' && x > 0;
+}
+
 async function executeSpecWithRetries(spec){
   let testExecutionIndex=0;
 
   while(true){
     try{
-      return await timeout(
-        spec.getPromise(), 
-        retryTimeoutInMiliseconds, 
-        new Error(`timeoutBeforeRetryError: timeout of ${retryTimeoutInMiliseconds}ms before retrying the test is exceeded. Ensure the 'done() callback is being called in this test.`)
-      );
+      if(!isPositiveNumber(retryTimeoutInMiliseconds)){
+        return await spec.getPromise();
+      }
+      else{
+        return await timeout(
+          spec.getPromise(), 
+          retryTimeoutInMiliseconds, 
+          new Error(`timeoutBeforeRetryError: timeout of ${retryTimeoutInMiliseconds}ms before retrying the test is exceeded. Ensure the 'done() callback is being called in this test.`)
+        );  
+      }
     }
     catch(err){
       retriedTestFailures.push({

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -44,8 +44,6 @@ var enabled = true;
 
 var maxRetries = 5;
 var retryTimeoutInMiliseconds = 240000;
-var retryDelayInMilisecondes = 5000;
-
 
 /**
  * Private function invoked by parallel.
@@ -218,10 +216,6 @@ parallel.maxRetries = function(x) {
 
 parallel.retryTimeoutInMiliseconds = function(x) {
   retryTimeoutInMiliseconds = x;
-};
-
-parallel.retryDelayInMilisecondes = function(x) {
-  retryDelayInMilisecondes = x;
 };
 
 parallel.getRetriedTestFailures = function(){
@@ -460,7 +454,6 @@ async function executeSpecWithRetries(spec){
       })      
 
       if(testExecutionIndex<maxRetries){
-        await sleep(retryDelayInMilisecondes);
         testExecutionIndex++;  
       }
       else{
@@ -477,11 +470,6 @@ function timeout(prom, time, exception){
 		new Promise((_r, rej) => timer = setTimeout(rej, time, exception))
 	]).finally(() => clearTimeout(timer));
 }
-
-function sleep(time){
-  return new Promise(resolve => setTimeout(resolve, time));
-}
-
 
 Promise.onPossiblyUnhandledRejection(function() {
   // Stop bluebird from printing the unhandled rejections

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -89,7 +89,9 @@ function _parallel(name, fn, key) {
         spec.promise = parentHooks.beforeEach()
           .cancellable()
           .then(hooks.beforeEach)
-          .then(spec.getPromise)
+          .then(async function(){
+            return executeSpecWithRetries(spec);
+          })
           .then(function() {
             clearTimeout(spec.timeout);
           })
@@ -414,6 +416,43 @@ function patchUncaught() {
     process.on(name, originalListener);
   };
 }
+
+const maxRetries = 2;
+const timeoutBeforeRetryInMiliseconds = 20000;
+async function executeSpecWithRetries(spec){
+  let testExecutionIndex=0;
+
+  while(true){
+    try{
+      return await timeout(
+        spec.getPromise(), 
+        timeoutBeforeRetryInMiliseconds, 
+        new Error(`timeoutBeforeRetryError: timeout of ${timeoutBeforeRetryInMiliseconds}ms before retrying the test is exceeded. Ensure the 'done() callback is being called in this test.`)
+      );
+    }
+    catch(err){
+      console.log(
+`"${spec.name}" failed ${testExecutionIndex+1} times. 
+Error: 
+${err}`
+      );
+
+      testExecutionIndex++;
+      if(testExecutionIndex>maxRetries){
+        throw err;
+      }
+    }
+  }
+}
+
+const timeout = (prom, time, exception) => {
+	let timer;
+	return Promise.race([
+		prom,
+		new Promise((_r, rej) => timer = setTimeout(rej, time, exception))
+	]).finally(() => clearTimeout(timer));
+}
+
 
 Promise.onPossiblyUnhandledRejection(function() {
   // Stop bluebird from printing the unhandled rejections

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -229,7 +229,7 @@ parallel.maxRetries = function(x) {
  * Ex: 
  * if a test hang forever and maxRetries=10, retryTimeoutInMiliseconds=1000 and 
  * mocha timeout is 5 secondes, then the test will be retried 5 times because 
- * retryTimeoutInMiliseconds but will stop as soon as Mocha timenout is readed.
+ * retryTimeoutInMiliseconds but will stop as soon as Mocha timeout is readed.
  * @param {int} n
  */
 parallel.retryTimeoutInMiliseconds = function(x) {

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -209,15 +209,37 @@ parallel.disable = function() {
   enabled = false;
 };
 
-
+/**
+ * If a test fails, it will be retried until it succeeds or maxRetries is reached.
+ * Useful if some tests have dependecies (ex: network) that fail from time to time.
+ * 
+ * @param {int} n
+ */
 parallel.maxRetries = function(x) {
   maxRetries = x;
 };
 
+/**
+ * If a test hang and maxRetries > 0, the test will be retried after retryTimeoutInMiliseconds
+ * retryTimeoutInMiliseconds does not alter the default timeout of Mocha.
+ * Ex: 
+ * if a test hang forever and maxRetries=10, retryTimeoutInMiliseconds=1000 and 
+ * mocha timeout is 5 secondes, then the test will be retried 5 times because 
+ * retryTimeoutInMiliseconds but will stop as soon as Mocha timenout is readed.
+ * @param {int} n
+ */
 parallel.retryTimeoutInMiliseconds = function(x) {
   retryTimeoutInMiliseconds = x;
 };
 
+/**
+ * getRetriedTestFailures allow to know what caused the test to be retried.
+ * maxRetries avoid failling the suite because of some flaky tests but flaky 
+ * tests should not be retried silently.
+ * getRetriedTestFailures can be used to include retried test failures in 
+ * a custom Mocha reporter. 
+ * For more details, see https://mochajs.org/api/tutorial-custom-reporter.html
+ */
 parallel.getRetriedTestFailures = function(){
   return [...retriedTestFailures];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,276 @@
 {
   "name": "mocha.parallel",
   "version": "0.15.6",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "mocha.parallel",
+      "version": "0.15.6",
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^2.9.34",
+        "semaphore": "^1.0.5"
+      },
+      "devDependencies": {
+        "dirmap": "0.0.2"
+      },
+      "peerDependencies": {
+        "mocha": ">=2.2.5"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "peer": true
+    },
+    "node_modules/bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "peer": true
+    },
+    "node_modules/commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "peer": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "peer": true
+    },
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dirmap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/dirmap/-/dirmap-0.0.2.tgz",
+      "integrity": "sha1-f4Cn2ZLZ/q2talqww90okesF5+Q=",
+      "dev": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "peer": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "peer": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "peer": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "peer": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "peer": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "peer": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "peer": true,
+      "dependencies": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "peer": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    }
+  },
   "dependencies": {
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "peer": true
     },
     "bluebird": {
       "version": "2.11.0",
@@ -18,30 +281,35 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "peer": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "peer": true
     },
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "peer": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "peer": true
     },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "peer": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -49,7 +317,8 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "peer": true
     },
     "dirmap": {
       "version": "0.0.2",
@@ -60,72 +329,83 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "peer": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "peer": true
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "peer": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "peer": true
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "peer": true
     },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "peer": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "peer": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "peer": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "peer": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "peer": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "peer": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -134,6 +414,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
       "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "peer": true,
       "requires": {
         "browser-stdout": "1.3.1",
         "commander": "2.15.1",
@@ -151,20 +432,23 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "peer": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "peer": true
     },
     "semaphore": {
       "version": "1.1.0",
@@ -175,14 +459,16 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "peer": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
     }
   }
 }

--- a/spec/fixtures/flakyAndDefaultTimeout.js
+++ b/spec/fixtures/flakyAndDefaultTimeout.js
@@ -1,0 +1,6 @@
+var parallel = require('../../lib/parallel');
+const flakySuite = require('./flakySuite');
+
+parallel.maxRetries(2);
+parallel.retryTimeoutInMiliseconds(5000);
+flakySuite(3000);

--- a/spec/fixtures/flakySuite.js
+++ b/spec/fixtures/flakySuite.js
@@ -1,0 +1,65 @@
+var parallel = require('../../lib/parallel');
+
+let i =0;
+
+function flakySuite(flakyDelay=100){
+  parallel('suite', function() {
+    it('good', function(done) {
+      setTimeout(done, 100);
+    });
+
+    it('bad', function(done) {
+      setTimeout(function() {
+        return done(new Error('Expected error'));
+      }, 100);
+    });
+
+    it('ugly', function(done) {
+      i++;
+      //fails half of the time
+      if(i%2===1){
+        setTimeout(function() {
+          return done(new Error('Flaky error'));
+        }, flakyDelay);
+      }
+      else{
+        setTimeout(done, 100);      
+      }
+    });
+
+    // after hook is a simplistic approach to building a reporter for flaky tests.
+    // Consider using .getRetriedTestFailures() to build a proper mocha reporter
+    after(async () => {
+      if(parallel.getRetriedTestFailures().length>0){
+        console.log("\n\nFlaky Tests:")
+        console.log(
+          parallel
+            .getRetriedTestFailures()
+            .sort(orderBySpecNameThenTestExecutionIndex)
+            .map((failedTest) =>
+              `- failed ${failedTest.testExecutionIndex + 1} times: ${failedTest.specName}\n${failedTest.err}`
+            )
+            .join("\n")
+        );  
+      }
+    });
+  });
+}
+
+function orderBySpecNameThenTestExecutionIndex(a, b) {
+  return a.specName == b.specName
+    ? compare(a.testExecutionIndex, b.testExecutionIndex)
+    : compare(a.specName, b.specName);
+}
+
+function compare(a, b) {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+}
+
+module.exports = flakySuite;

--- a/spec/fixtures/flakySuite.js
+++ b/spec/fixtures/flakySuite.js
@@ -29,6 +29,7 @@ function flakySuite(flakyDelay=100){
 
     // after hook is a simplistic approach to building a reporter for flaky tests.
     // Consider using .getRetriedTestFailures() to build a proper mocha reporter
+    // For more details, see https://mochajs.org/api/tutorial-custom-reporter.html
     after(async () => {
       if(parallel.getRetriedTestFailures().length>0){
         console.log("\n\nFlaky Tests:")

--- a/spec/fixtures/flakyWithDefaultArgs.js
+++ b/spec/fixtures/flakyWithDefaultArgs.js
@@ -1,0 +1,4 @@
+var parallel = require('../../lib/parallel');
+const flakySuite = require('./flakySuite');
+
+flakySuite();

--- a/spec/fixtures/flakyWithRetries.js
+++ b/spec/fixtures/flakyWithRetries.js
@@ -1,0 +1,5 @@
+var parallel = require('../../lib/parallel');
+const flakySuite = require('./flakySuite');
+
+parallel.maxRetries(2);
+flakySuite();

--- a/spec/fixtures/flakyWithRetryTimeout.js
+++ b/spec/fixtures/flakyWithRetryTimeout.js
@@ -1,0 +1,6 @@
+var parallel = require('../../lib/parallel');
+const flakySuite = require('./flakySuite');
+
+parallel.maxRetries(2);
+parallel.retryTimeoutInMiliseconds(500);
+flakySuite(1000);

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -304,6 +304,54 @@ describe('parallel', function() {
       done();
     });
   });
+
+  it('can retry failing tests if maxRetries is specified', function(done) {
+    run(fixtures.flakyWithRetries, function(err, stdout, stderr) {
+      assert(err);
+      assert(stdout.indexOf('bad:') !== -1,"bad is part of the standard error report");
+      assert(stdout.indexOf('failed 3 times: bad') !== -1,"bad is part of the flaky tests section");
+      assert(stdout.indexOf('ugly:') === -1,"ugly is not part of the standard error report");
+      assert(stdout.indexOf('failed 1 times: ugly') !== -1,"ugly is part of the flaky tests section");
+      assert(stdout.indexOf('failed 2 times: ugly') === -1,"ugly failed only once");
+      assert(stdout.indexOf('Error: Flaky error') !== -1,"ugly has a flaky error");
+      
+      done();
+    });
+  });
+
+  it('maxRetries is an opt in arg', function(done) {
+    run(fixtures.flakyWithDefaultArgs, function(err, stdout, stderr) {
+      assert(err);
+      assert(stdout.indexOf('Flaky Tests:') === -1,"No Flaky tests section if maxRetries is not specified");
+      assert(stdout.indexOf('bad:') !== -1,"bad is part of the standard error report");
+      assert(stdout.indexOf('ugly:') !== -1,"ugly is part of the standard error report");
+
+      done();
+    });
+  });
+
+  it('can retry tests that hang if retryTimeoutInMiliseconds is specified', function(done) {
+    run(fixtures.flakyWithRetryTimeout, function(err, stdout, stderr) {
+      assert(err);
+      assert(stdout.indexOf('bad:') !== -1,"bad is part of the standard error report");
+      assert(stdout.indexOf('failed 3 times: bad') !== -1,"bad is part of the flaky tests section");
+      assert(stdout.indexOf('ugly:') === -1,"ugly is not part of the standard error report");
+      assert(stdout.indexOf('failed 1 times: ugly') !== -1,"ugly is part of the flaky tests section");
+      assert(stdout.indexOf('failed 2 times: ugly') === -1,"ugly failed only once");
+      assert(stdout.indexOf('Error: timeoutBeforeRetryError: timeout of 500ms') !== -1,"ugly has a timeout error");
+
+      done();
+    });
+  });
+
+  it('retryTimeoutInMiliseconds does not change the default timeout behaviour of Mocha', function(done) {
+    run(fixtures.flakyAndDefaultTimeout, function(err, stdout, stderr) {
+      assert(err);
+      stdout.indexOf('timeout of 2000ms exceeded');
+
+      done();
+    });
+  });
 });
 
 /**

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -300,7 +300,7 @@ describe('parallel', function() {
   it('correctly handles promise rejections', function(done) {
     run(fixtures.promiseRejection, function(err, stdout, stderr) {
       assert(err);
-      assert(stdout.indexOf('false == true') !== -1);
+      assert(stdout.indexOf('expression evaluated to a falsy value') !== -1);
       done();
     });
   });


### PR DESCRIPTION
Fix for https://github.com/danielstjules/mocha.parallel/issues/53

These new features are used to improve mocha-concurrent-api-tests and provide a detail for flaky tests in the test report.
For more details see: 
https://github.com/VilledeMontreal/mocha-concurrent-api-tests/blob/master/example/README.md#test-report-exemple-when-a-test-fails-or-does-not-succeed-on-the-first-time-flaky

/**
 * If a test fails, it will be retried until it succeeds or maxRetries is reached.
 * Useful if some tests have dependecies (ex: network) that fail from time to time.
 * 
 * @param {int} n
 */
parallel.maxRetries(n)

/**
 * If a test hang and maxRetries > 0, the test will be retried after retryTimeoutInMiliseconds
 * retryTimeoutInMiliseconds does not alter the default timeout of Mocha.
 * Ex: 
 * if a test hang forever and maxRetries=10, retryTimeoutInMiliseconds=1000 and 
 * mocha timeout is 5 secondes, then the test will be retried 5 times because 
 * retryTimeoutInMiliseconds but will stop as soon as Mocha timeout is readed.
 * @param {int} n
 */
parallel.retryTimeoutInMiliseconds(n)

/**
 * getRetriedTestFailures allow to know what caused the test to be retried.
 * maxRetries avoid failling the suite because of some flaky tests but flaky 
 * tests should not be retried silently.
 * getRetriedTestFailures can be used to include retried test failures in 
 * a custom Mocha reporter. 
 * For more details, see https://mochajs.org/api/tutorial-custom-reporter.html
 */
parallel.getRetriedTestFailures()